### PR TITLE
Remove texCoord from Vertex struct

### DIFF
--- a/include/HammerEngine/HammerEngine.h
+++ b/include/HammerEngine/HammerEngine.h
@@ -26,7 +26,6 @@
 struct Vertex {
     glm::vec3 pos;
     glm::vec3 color;
-    glm::vec2 texCoord;
 
     static VkVertexInputBindingDescription getBindingDescription();
     static std::array<VkVertexInputAttributeDescription, 3> getAttributeDescriptions();


### PR DESCRIPTION
Remove the glm::vec2 texCoord member from the Vertex struct in HammerEngine.h. This change drops per-vertex texture coordinates and may require updating vertex input attribute descriptions, pipeline / shader code, and any codepaths that previously accessed vertex.texCoord.
